### PR TITLE
Support cleaning nested Flutter/Dart projects

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,1 +1,1 @@
-include: package:dartclub_lint/analysis_options.yaml
+include: package:lints/recommended.yaml

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,19 +1,19 @@
 name: dart_clean
 description: dart_clean – clean dart and flutter repositories rercursively
-version: 0.1.3
+version: 0.2.0
 homepage: https://github.com/dartclub/dart_clean
 repository: https://github.com/dartclub/dart_clean
 
 environment:
-  sdk: '>=2.7.0 <3.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
-  path: ^1.7.0
-  yaml: ^2.2.1
+  path: ^1.8.3
+  yaml: ^3.1.2
 
 
 dev_dependencies:
-  dartclub_lint: ^0.2.1
+  lints: ^2.1.1
 
 executables:
   dart_clean: main


### PR DESCRIPTION
This is an extension of #1 

It adds support for cleaning nested Dart/Flutter directories. Currently, when a "cleanable" folder is found the tool doesn't keep looking recursively in that folder. Sometimes there could be a pubspec file at the root and some other nested packages inside. For example https://github.com/simolus3/drift does this.

What I did is to keep navigating when inside a Dart/Flutter folder but ignoring bin, lib and test, which would contain source code and not other possible subprojects.